### PR TITLE
Add a refresh button next to current weather

### DIFF
--- a/app/src/main/java/kenneth/app/starlightlauncher/views/DateTimeView.kt
+++ b/app/src/main/java/kenneth/app/starlightlauncher/views/DateTimeView.kt
@@ -13,6 +13,7 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.lifecycle.Lifecycle
@@ -28,6 +29,7 @@ import kenneth.app.starlightlauncher.api.OpenWeatherApi
 import kenneth.app.starlightlauncher.databinding.DateTimeViewBinding
 import kenneth.app.starlightlauncher.prefs.datetime.DateTimePreferenceManager
 import kenneth.app.starlightlauncher.api.util.activity
+import kenneth.app.starlightlauncher.api.view.IconButton
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -118,6 +120,11 @@ internal class DateTimeView(context: Context, attrs: AttributeSet) :
         }
         activity?.lifecycle?.addObserver(this)
         sharedPreferences.registerOnSharedPreferenceChangeListener(this)
+
+        binding.refreshWeatherBtn.setOnClickListener {
+            (it as IconButton).disabled = true
+            showWeather()
+        }
     }
 
     override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
@@ -263,6 +270,18 @@ internal class DateTimeView(context: Context, attrs: AttributeSet) :
                 binding.apply {
                     isWeatherShown = true
                     weatherIcon.contentDescription = weather.weather[0].description
+                    if (refreshWeatherBtn.disabled) {
+                        // this loadWeather call is triggered
+                        // by the refresh btn
+                        // re-enable the button and tell user weather is updated
+                        refreshWeatherBtn.disabled = false
+                        Toast.makeText(
+                            context,
+                            R.string.weather_updated_message,
+                            Toast.LENGTH_SHORT
+                        )
+                            .show()
+                    }
                 }
             } ?: kotlin.run {
                 binding.isWeatherShown = false

--- a/app/src/main/res/drawable/ic_redo.xml
+++ b/app/src/main/res/drawable/ic_redo.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M21,11a1,1 0,0 0,-1 1,8.05 8.05,0 1,1 -2.22,-5.5h-2.4a1,1 0,0 0,0 2h4.53a1,1 0,0 0,1 -1V3a1,1 0,0 0,-2 0V4.77A10,10 0,1 0,22 12,1 1,0 0,0 21,11Z"
+      android:fillColor="#0092E4"/>
+</vector>

--- a/app/src/main/res/layout/date_time_view.xml
+++ b/app/src/main/res/layout/date_time_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
@@ -62,6 +63,19 @@
                 android:contentDescription="@string/weather_image_description"
                 android:elevation="4dp"
                 android:visibility="@{isWeatherShown ? View.VISIBLE : View.GONE}" />
+
+            <Space
+                android:layout_width="8dp"
+                android:layout_height="0dp"
+                android:visibility="@{isWeatherShown ? View.VISIBLE : View.GONE}" />
+
+            <kenneth.app.starlightlauncher.api.view.IconButton
+                android:id="@+id/refresh_weather_btn"
+                android:layout_width="@dimen/weather_refresh_button_size"
+                android:layout_height="@dimen/weather_refresh_button_size"
+                android:src="@drawable/ic_redo"
+                android:visibility="@{isWeatherShown ? View.VISIBLE : View.GONE}"
+                app:tint="?android:attr/textColor" />
 
         </LinearLayout>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -53,4 +53,6 @@
     <dimen name="available_widgets_list_app_icon_size">40dp</dimen>
     <dimen name="available_widgets_list_app_icon_padding_end">16dp</dimen>
     <dimen name="available_widgets_list_preview_padding_bottom">16dp</dimen>
+
+    <dimen name="weather_refresh_button_size">16dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="date_time_weather_separator">·</string>
     <string name="date_time_temperature_format">%1$.1f %2$s</string>
     <string name="weather_image_description">Icon of the current weather</string>
+    <string name="weather_updated_message">Weather updated</string>
 
     <!-- Widgets panel -->
     <string name="widgets_panel_edit_mode_header">Long press a widget to edit it.</string>


### PR DESCRIPTION
This PR adds a refresh button next to current weather so that users can manually refresh the weather to get the latest info. Upon refresh, a toast is shown to indicate successful refresh.

Closes #14 