### PR TITLE
Allow back button to clear search box content

### DIFF
--- a/app/src/main/java/kenneth/app/starlightlauncher/views/SearchBox.kt
+++ b/app/src/main/java/kenneth/app/starlightlauncher/views/SearchBox.kt
@@ -106,6 +106,13 @@ internal class SearchBox(context: Context, attrs: AttributeSet) : LinearLayout(c
         binding.searchBoxEditText.clearFocus()
     }
 
+    /**
+     * Clears the content of the search box.
+     */
+    fun clear() {
+        binding.searchBoxEditText.text.clear()
+    }
+
     fun showTopPadding() {
         createPaddingAnimation(showTopPadding = true).start()
     }
@@ -143,7 +150,7 @@ internal class SearchBox(context: Context, attrs: AttributeSet) : LinearLayout(c
     private fun onRightSideButtonClicked() {
         when {
             hasQueryText -> {
-                binding.searchBoxEditText.text.clear()
+                clear()
                 showRetractWidgetPanelButton()
             }
             BindingRegister.activityMainBinding.widgetsPanel.isExpanded -> {

--- a/app/src/main/java/kenneth/app/starlightlauncher/widgets/widgetspanel/WidgetsPanel.kt
+++ b/app/src/main/java/kenneth/app/starlightlauncher/widgets/widgetspanel/WidgetsPanel.kt
@@ -94,8 +94,12 @@ internal class WidgetsPanel(context: Context, attrs: AttributeSet) :
 
         onBackPressedCallback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                if (isExpanded && !isEditModeEnabled && !binding.searchBox.hasQueryText) {
-                    retract()
+                if (isExpanded && !isEditModeEnabled) {
+                    if (binding.searchBox.hasQueryText) {
+                        binding.searchBox.clear()
+                    } else {
+                        retract()
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR adds logic to allow search box content and search result page to be cleared when the back button is pressed.

Closes #19 