### PR TITLE
All notes overlay layout improvements

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -149,7 +149,7 @@
         <entry key="notes-widget/src/main/res/drawable/ic_trash_alt.xml" value="0.21302083333333333" />
         <entry key="notes-widget/src/main/res/drawable/note_card_background.xml" value="0.3703125" />
         <entry key="notes-widget/src/main/res/drawable/notes_widget_settings_icon.xml" value="0.159" />
-        <entry key="notes-widget/src/main/res/layout/all_notes.xml" value="0.3536458333333333" />
+        <entry key="notes-widget/src/main/res/layout/all_notes.xml" value="0.1" />
         <entry key="notes-widget/src/main/res/layout/file_name_dialog_content.xml" value="0.3428442028985507" />
         <entry key="notes-widget/src/main/res/layout/note_card.xml" value="0.12222222222222222" />
         <entry key="notes-widget/src/main/res/layout/notes_widget.xml" value="0.3390625" />

--- a/app/src/main/java/kenneth/app/starlightlauncher/widgets/widgetspanel/Overlay.kt
+++ b/app/src/main/java/kenneth/app/starlightlauncher/widgets/widgetspanel/Overlay.kt
@@ -3,14 +3,20 @@ package kenneth.app.starlightlauncher.widgets.widgetspanel
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.content.Context
+import android.graphics.Rect
 import android.util.AttributeSet
+import android.util.Log
 import android.view.View
+import android.view.ViewTreeObserver
+import android.view.WindowInsets
 import android.view.animation.PathInterpolator
 import androidx.activity.OnBackPressedCallback
 import androidx.core.animation.addListener
-import androidx.core.view.isVisible
+import androidx.core.view.*
+import androidx.lifecycle.LifecycleOwner
 import dagger.hilt.android.AndroidEntryPoint
 import kenneth.app.starlightlauncher.AppState
+import kenneth.app.starlightlauncher.R
 import kenneth.app.starlightlauncher.api.util.BlurHandler
 import kenneth.app.starlightlauncher.api.view.Plate
 import kenneth.app.starlightlauncher.api.util.activity
@@ -29,7 +35,10 @@ private val SHOW_OVERLAY_ANIMATION_PATH_INTERPOLATOR =
  * Widgets can use this to display additional info.
  */
 @AndroidEntryPoint
-internal class Overlay(context: Context, attrs: AttributeSet) : Plate(context, attrs) {
+internal class Overlay(context: Context, attrs: AttributeSet) :
+    Plate(context, attrs),
+    ViewTreeObserver.OnGlobalFocusChangeListener,
+    OnApplyWindowInsetsListener {
     @Inject
     lateinit var appState: AppState
 
@@ -51,12 +60,21 @@ internal class Overlay(context: Context, attrs: AttributeSet) : Plate(context, a
      */
     private var content: View? = null
 
+    private var focusedView: View? = null
+    private var originalTranslationY: Float? = null
+
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
             if (isVisible && !isClosing) {
                 close()
             }
         }
+    }
+
+    init {
+        ViewCompat.setWindowInsetsAnimationCallback(this, InsetsAnimation())
+        ViewCompat.setOnApplyWindowInsetsListener(this, this)
+        viewTreeObserver.addOnGlobalFocusChangeListener(this)
     }
 
     /**
@@ -112,10 +130,85 @@ internal class Overlay(context: Context, attrs: AttributeSet) : Plate(context, a
         onBackPressedCallback.remove()
     }
 
+    override fun onApplyWindowInsets(v: View, insets: WindowInsetsCompat): WindowInsetsCompat {
+        // translate the overlay for the inset
+        // this translation will be animated by InsetsAnimation
+
+        val focusedView = this.focusedView ?: return insets
+
+        val y = IntArray(2).run {
+            focusedView.getLocationOnScreen(this)
+            this[1] + focusedView.height
+        }
+        val imeHeight = insets
+            .getInsets(WindowInsetsCompat.Type.ime())
+            .bottom
+        // y coordinate of the top of ime
+        val imeY = appState.screenHeight - imeHeight
+
+        if (imeHeight > 0) {
+            originalTranslationY = translationY
+            translationY -= Integer.max(0, y + 100 - imeY)
+        } else {
+            originalTranslationY?.let { translationY = it }
+        }
+
+        return insets
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        viewTreeObserver.removeOnGlobalFocusChangeListener(this)
+        super.onDestroy(owner)
+    }
+
+    override fun onGlobalFocusChanged(oldFocus: View?, newFocus: View?) {
+        focusedView = newFocus
+    }
+
     private fun displayContent(content: View) {
         if (childCount > 1) {
             removeViewAt(1)
         }
         addView(content)
+    }
+
+    private inner class InsetsAnimation : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_STOP) {
+        private var startTranslationY: Float? = null
+        private var endTranslationY: Float? = null
+
+        override fun onPrepare(animation: WindowInsetsAnimationCompat) {
+            Log.d("starlight", "startTranslationY $translationY")
+            startTranslationY = translationY
+            super.onPrepare(animation)
+        }
+
+        override fun onStart(
+            animation: WindowInsetsAnimationCompat,
+            bounds: WindowInsetsAnimationCompat.BoundsCompat
+        ): WindowInsetsAnimationCompat.BoundsCompat {
+            endTranslationY = translationY
+            originalTranslationY?.let { translationY = it }
+            return super.onStart(animation, bounds)
+        }
+
+        override fun onProgress(
+            insets: WindowInsetsCompat,
+            runningAnimations: MutableList<WindowInsetsAnimationCompat>
+        ): WindowInsetsCompat {
+            val startTranslationY = this.startTranslationY ?: return insets
+            val endTranslationY = this.endTranslationY ?: return insets
+
+            // Find an IME animation.
+            val imeAnimation = runningAnimations.find {
+                it.typeMask and WindowInsetsCompat.Type.ime() != 0
+            } ?: return insets
+
+            val delta = startTranslationY - endTranslationY
+
+            // Offset the view based on the interpolated fraction of the IME animation.
+            translationY = startTranslationY - (delta * imeAnimation.interpolatedFraction)
+
+            return insets
+        }
     }
 }

--- a/notes-widget/src/main/java/kenneth/app/starlightlauncher/noteswidget/view/AllNotes.kt
+++ b/notes-widget/src/main/java/kenneth/app/starlightlauncher/noteswidget/view/AllNotes.kt
@@ -2,15 +2,29 @@ package kenneth.app.starlightlauncher.noteswidget.view
 
 import android.content.Context
 import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewTreeObserver
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.recyclerview.widget.LinearLayoutManager
+import kenneth.app.starlightlauncher.api.util.dp
 import kenneth.app.starlightlauncher.noteswidget.R
 import kenneth.app.starlightlauncher.noteswidget.databinding.AllNotesBinding
 
 class AllNotes(context: Context) : FrameLayout(context) {
     private val binding = AllNotesBinding.inflate(LayoutInflater.from(context), this)
     private val listAdapter: AllNoteCardListAdapter
+
+    private val globalLayoutListener = object : ViewTreeObserver.OnGlobalLayoutListener {
+        override fun onGlobalLayout() {
+            with(binding.noteCardListScrollView) {
+                updatePadding(bottom = binding.addNoteButton.height + 24.dp)
+                smoothScrollTo(0, 0)
+            }
+            viewTreeObserver.removeOnGlobalLayoutListener(this)
+        }
+    }
 
     init {
         layoutParams = LayoutParams(
@@ -19,15 +33,20 @@ class AllNotes(context: Context) : FrameLayout(context) {
         )
 
         val topPadding = resources.getDimensionPixelOffset(R.dimen.overlay_padding_top)
-        setPadding(0, topPadding, 0, 0)
 
         with(binding) {
+            addNoteButton.setOnClickListener { addNote() }
+            noteCardListScrollView.apply {
+                setPadding(0, topPadding, 0, addNoteButton.height)
+                clipToPadding = false
+            }
             noteCardList.apply {
                 adapter = AllNoteCardListAdapter(context).also { listAdapter = it }
                 layoutManager = LinearLayoutManager(context)
             }
-            addNoteButton.setOnClickListener { addNote() }
         }
+
+        viewTreeObserver.addOnGlobalLayoutListener(globalLayoutListener)
     }
 
     private fun addNote() {


### PR DESCRIPTION
This PR includes improvements to the All notes overlay triggered by the notes widget when tapping on "See all".

- Add note button no longer blocks the content
- Top padding no longer clips the content
- Keyboard no longer blocks notes being edited

Closes #16 