### PR TITLE
Allow custom OpenWeatherMap api key to be set

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true">
+        <option name="RIGHT_MARGIN" value="50" />
+      </inspection_tool>
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/starlight_launcher_name"
-        android:launchMode="singleTask"
+        android:launchMode="singleTop"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:stateNotNeeded="true"
         android:supportsRtl="true"
@@ -60,6 +60,7 @@
             android:name=".setup.SetupActivity"
             android:exported="false"
             android:label="@string/setup_activity_label"
+            android:launchMode="singleTop"
             android:theme="@style/DarkLauncherTheme" />
 
         <activity
@@ -73,7 +74,7 @@
             android:configChanges="uiMode"
             android:excludeFromRecents="true"
             android:exported="true"
-            android:launchMode="singleTask"
+            android:launchMode="singleTop"
             android:screenOrientation="nosensor"
             android:windowSoftInputMode="stateVisible">
 

--- a/app/src/main/java/kenneth/app/starlightlauncher/api/OpenWeatherApi.kt
+++ b/app/src/main/java/kenneth/app/starlightlauncher/api/OpenWeatherApi.kt
@@ -53,6 +53,8 @@ class OpenWeatherApi @Inject constructor(
      */
     var unit: TemperatureUnit = TemperatureUnit.CELSIUS
 
+    var apiKey = BuildConfig.OPEN_WEATHER_API_KEY
+
     /**
      * Fetches the current weather of the location specified by latLong
      */
@@ -64,7 +66,7 @@ class OpenWeatherApi @Inject constructor(
             .addQueryParameter("units", unit.code)
             .addQueryParameter("lat", lat.toString())
             .addQueryParameter("lon", long.toString())
-            .addQueryParameter("appid", BuildConfig.OPEN_WEATHER_API_KEY)
+            .addQueryParameter("appid", apiKey)
             .build()
 
         val req = Request.Builder().url(url).build()

--- a/app/src/main/java/kenneth/app/starlightlauncher/datetime/ClockSettingsScreen.kt
+++ b/app/src/main/java/kenneth/app/starlightlauncher/datetime/ClockSettingsScreen.kt
@@ -24,6 +24,7 @@ internal fun ClockSettingsScreen(
     viewModel: ClockSettingsScreenViewModel = hiltViewModel(),
 ) {
     var isLocationPickerOpen by remember { mutableStateOf(false) }
+    var isWeatherApiKeyDialogOpen by remember { mutableStateOf(false) }
 
     val context = LocalContext.current
     val permissionRequestLauncher = rememberLauncherForActivityResult(
@@ -73,6 +74,13 @@ internal fun ClockSettingsScreen(
                     summary = stringResource(R.string.date_time_show_weather_summary),
                     checked = viewModel.shouldShowWeather,
                     onCheckedChange = { viewModel.changeShouldShowWeather(it) }
+                )
+
+                SettingsListItem(
+                    icon = painterResource(R.drawable.ic_key_skeleton),
+                    title = stringResource(R.string.date_time_custom_api_key_title),
+                    summary = stringResource(R.string.date_time_custom_api_key_summary),
+                    onTap = { isWeatherApiKeyDialogOpen = true }
                 )
 
                 AnimatedVisibility(
@@ -158,6 +166,14 @@ internal fun ClockSettingsScreen(
             WeatherLocationPicker(
                 onDismissRequest = { isLocationPickerOpen = false },
                 onLocationSelected = { viewModel.changeWeatherLocation(it) }
+            )
+        }
+
+        if (isWeatherApiKeyDialogOpen) {
+            WeatherApiKeyDialog(
+                onDismissRequest = { isWeatherApiKeyDialogOpen = false },
+                onApiKeySelected = { viewModel.changeWeatherApiKey(it) },
+                onDefaultApiKeySelected = { viewModel.useDefaultWeatherApiKey() }
             )
         }
     }

--- a/app/src/main/java/kenneth/app/starlightlauncher/datetime/ClockSettingsScreenViewModel.kt
+++ b/app/src/main/java/kenneth/app/starlightlauncher/datetime/ClockSettingsScreenViewModel.kt
@@ -6,8 +6,8 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kenneth.app.starlightlauncher.BuildConfig
 import kenneth.app.starlightlauncher.api.LatLong
-import kenneth.app.starlightlauncher.api.NominatimApi
 import kenneth.app.starlightlauncher.api.Place
 import kenneth.app.starlightlauncher.api.TemperatureUnit
 import kotlinx.coroutines.flow.collectLatest
@@ -40,6 +40,9 @@ internal class ClockSettingsScreenViewModel @Inject constructor(
         private set
 
     var weatherLocationName by mutableStateOf<String?>(null)
+        private set
+
+    var weatherApiKey by mutableStateOf(BuildConfig.OPEN_WEATHER_API_KEY)
         private set
 
     init {
@@ -82,6 +85,11 @@ internal class ClockSettingsScreenViewModel @Inject constructor(
             launch {
                 dateTimePreferenceManager.weatherLocationName.collectLatest {
                     weatherLocationName = it
+                }
+            }
+            launch {
+                dateTimePreferenceManager.weatherApiKey.collectLatest {
+                    weatherApiKey = it
                 }
             }
         }
@@ -135,6 +143,18 @@ internal class ClockSettingsScreenViewModel @Inject constructor(
                 LatLong(place.lat, place.long),
                 place.displayName
             )
+        }
+    }
+
+    fun changeWeatherApiKey(apiKey: String) {
+        viewModelScope.launch {
+            dateTimePreferenceManager.changeWeatherApiKey(apiKey)
+        }
+    }
+
+    fun useDefaultWeatherApiKey() {
+        viewModelScope.launch {
+            dateTimePreferenceManager.useDefaultWeatherApiKey()
         }
     }
 }

--- a/app/src/main/java/kenneth/app/starlightlauncher/datetime/DateTimePreferenceManager.kt
+++ b/app/src/main/java/kenneth/app/starlightlauncher/datetime/DateTimePreferenceManager.kt
@@ -3,6 +3,7 @@ package kenneth.app.starlightlauncher.datetime
 import android.content.Context
 import androidx.datastore.preferences.core.edit
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kenneth.app.starlightlauncher.BuildConfig
 import kenneth.app.starlightlauncher.R
 import kenneth.app.starlightlauncher.api.LatLong
 import kenneth.app.starlightlauncher.api.TemperatureUnit
@@ -92,6 +93,10 @@ internal class DateTimePreferenceManager @Inject constructor(
         }
         .distinctUntilChanged()
 
+    val weatherApiKey = context.dataStore.data
+        .map { it[PREF_KEY_WEATHER_API_KEY] ?: BuildConfig.OPEN_WEATHER_API_KEY }
+        .distinctUntilChanged()
+
     /**
      * Changes the weather location described by the given LatLong.
      */
@@ -142,6 +147,18 @@ internal class DateTimePreferenceManager @Inject constructor(
     suspend fun changeWeatherUnit(unit: TemperatureUnit) {
         context.dataStore.edit {
             it[PREF_KEY_WEATHER_UNIT] = unit.code
+        }
+    }
+
+    suspend fun changeWeatherApiKey(apiKey: String) {
+        context.dataStore.edit {
+            it[PREF_KEY_WEATHER_API_KEY] = apiKey
+        }
+    }
+
+    suspend fun useDefaultWeatherApiKey() {
+        context.dataStore.edit {
+            it.remove(PREF_KEY_WEATHER_API_KEY)
         }
     }
 }

--- a/app/src/main/java/kenneth/app/starlightlauncher/datetime/WeatherApiKeyDialog.kt
+++ b/app/src/main/java/kenneth/app/starlightlauncher/datetime/WeatherApiKeyDialog.kt
@@ -1,0 +1,68 @@
+package kenneth.app.starlightlauncher.datetime
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import kenneth.app.starlightlauncher.R
+import kenneth.app.starlightlauncher.api.compose.pref.SETTINGS_LIST_ITEM_ICON_SIZE
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WeatherApiKeyDialog(
+    onDismissRequest: () -> Unit,
+    onApiKeySelected: (apiKey: String) -> Unit,
+    onDefaultApiKeySelected: () -> Unit,
+) {
+    var apiKey by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        icon = {
+            Image(
+                painter = painterResource(R.drawable.ic_key_skeleton),
+                contentDescription = "",
+                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary),
+                modifier = Modifier
+                    .width(SETTINGS_LIST_ITEM_ICON_SIZE)
+                    .height(SETTINGS_LIST_ITEM_ICON_SIZE),
+            )
+        },
+        title = {
+            Text(stringResource(R.string.date_time_custom_api_key_dialog_title))
+        },
+        text = {
+            TextField(
+                value = apiKey,
+                onValueChange = { apiKey = it },
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onApiKeySelected(apiKey) }) {
+                Text(stringResource(R.string.date_time_custom_api_key_dialog_confirm_button))
+            }
+        },
+        dismissButton = {
+            Row {
+                TextButton(
+                    onClick = {
+                        onDefaultApiKeySelected()
+                        onDismissRequest()
+                    }
+                ) {
+                    Text(stringResource(R.string.date_time_custom_api_key_dialog_use_default_key_button))
+                }
+
+                TextButton(onClick = { onDismissRequest() }) {
+                    Text(stringResource(R.string.action_cancel))
+                }
+            }
+        },
+    )
+}

--- a/app/src/main/java/kenneth/app/starlightlauncher/home/MainScreenViewModel.kt
+++ b/app/src/main/java/kenneth/app/starlightlauncher/home/MainScreenViewModel.kt
@@ -17,6 +17,7 @@ import android.util.Log
 import androidx.lifecycle.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kenneth.app.starlightlauncher.BuildConfig
 import kenneth.app.starlightlauncher.api.LatLong
 import kenneth.app.starlightlauncher.api.OpenWeatherApi
 import kenneth.app.starlightlauncher.api.TemperatureUnit
@@ -175,6 +176,8 @@ internal class MainScreenViewModel @Inject constructor(
 
     private var isLoadingWeather = false
 
+    private var weatherApiKey = BuildConfig.OPEN_WEATHER_API_KEY
+
     init {
         if (isNotificationListenerEnabled.value == true) {
             observeActiveMediaSession()
@@ -240,6 +243,12 @@ internal class MainScreenViewModel @Inject constructor(
             launch {
                 appearancePreferenceManager.isAppDrawerEnabled.collectLatest {
                     _isAllAppsScreenEnabled.postValue(it)
+                }
+            }
+
+            launch {
+                dateTimePreferenceManager.weatherApiKey.collectLatest {
+                    weatherApiKey = it
                 }
             }
         }
@@ -467,6 +476,7 @@ internal class MainScreenViewModel @Inject constructor(
             .run {
                 latLong = location
                 unit = weatherUnit ?: dateTimePreferenceManager.weatherUnit.first()
+                apiKey = weatherApiKey
                 getCurrentWeather()
             }
             .getOrNull()

--- a/app/src/main/java/kenneth/app/starlightlauncher/prefs/PrefKeys.kt
+++ b/app/src/main/java/kenneth/app/starlightlauncher/prefs/PrefKeys.kt
@@ -33,5 +33,6 @@ val PREF_KEY_WEATHER_LOCATION_LAT = floatPreferencesKey("date_time_weather_locat
 val PREF_KEY_WEATHER_LOCATION_LONG = floatPreferencesKey("date_time_weather_location_lat")
 val PREF_KEY_WEATHER_LOCATION_NAME = stringPreferencesKey("date_time_weather_location_name")
 val PREF_KEY_WEATHER_UNIT = stringPreferencesKey("date_time_weather_unit")
+val PREF_KEY_WEATHER_API_KEY = stringPreferencesKey("weather_api_key")
 
 val PREF_NOTE_LIST = stringPreferencesKey("note_list")

--- a/app/src/main/res/drawable/ic_key_skeleton.xml
+++ b/app/src/main/res/drawable/ic_key_skeleton.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M21,4.41l0.71,-0.7a1,1 0,1 0,-1.42 -1.42L18.89,3.7h0L16.06,6.53h0L9.75,12.83a5,5 0,1 0,1.42 1.42l5.59,-5.6 2.12,2.13a1,1 0,1 0,1.41 -1.42L18.17,7.24l1.42,-1.41 0.7,0.7a1,1 0,1 0,1.42 -1.41ZM7,20a3,3 0,1 1,3 -3A3,3 0,0 1,7 20Z"
+      android:fillColor="#0092E4"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,6 +246,13 @@
     <string name="date_time_show_weather_summary">
         Shows current weather next to the current date.
     </string>
+    <string name="date_time_custom_api_key_title">Set API Key…</string>
+    <string name="date_time_custom_api_key_summary">
+        Use my own OpenWeatherMap API key to fetch weather data instead of the default key.
+    </string>
+    <string name="date_time_custom_api_key_dialog_title">Set OpenWeatherMap API Key</string>
+    <string name="date_time_custom_api_key_dialog_confirm_button">Save</string>
+    <string name="date_time_custom_api_key_dialog_use_default_key_button">Use default key</string>
     <string name="date_time_pick_location_title">Pick a location…</string>
     <string name="date_time_pick_location_summary">
         Starlight will show weather at the specified location: %1$s


### PR DESCRIPTION
This PR adds the ability to change the OpenWeatherMap API key that is used to fetch weather data.